### PR TITLE
TM09-73 add geolocation api

### DIFF
--- a/packages/client/src/pages/gamePage/components/TrafficRacer/TrafficRacer.tsx
+++ b/packages/client/src/pages/gamePage/components/TrafficRacer/TrafficRacer.tsx
@@ -5,6 +5,7 @@ import { Scenario, Car, Traffic, GameConfig, crashSound } from '../../utils';
 import './TrafficRacer.scss';
 import { getIsSoundOn } from '@/utils/store/selectors/getAppStatusSelectors/getAppStatusSelectors';
 import gameSoundPath from '../../assets/sounds/gameSound.mp3';
+import useGeolocation from '@/pages/gamePage/hooks/useGeolocation';
 
 type TrafficRacerProps = {
   height: number;
@@ -27,6 +28,8 @@ export const TrafficRacer: Props = memo(({ height, setGameStarted, setGameOver, 
   const gameThemeSound = useRef<HTMLAudioElement | null>(null);
   let speed = GameConfig.level.initialSpeed;
   let playedCrash: boolean;
+  const { city } = useGeolocation();
+
   const setSpeed = (newSpeed: number) => {
     speed = newSpeed;
   };
@@ -178,6 +181,10 @@ export const TrafficRacer: Props = memo(({ height, setGameStarted, setGameOver, 
     if (scenario.current) scenario.current.setRoadImageHeight(height);
     if (player.current) player.current.setY(height - GameConfig.traffic.carHeight - 10);
   }, [height]);
+
+  useEffect(() => {
+    if (city) GameConfig.player.city = city;
+  }, [city]);
 
   return (
     <div className="traffic-racer" style={{ backgroundColor: GameConfig.general.background }}>

--- a/packages/client/src/pages/gamePage/hooks/useGeolocation.ts
+++ b/packages/client/src/pages/gamePage/hooks/useGeolocation.ts
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import { createApiDef } from '@/utils/api/createApiDef';
+
+interface IGeolocationPositionError {
+  readonly code: number;
+  readonly message: string;
+}
+
+interface IGeolocationState {
+  latitude: number | null;
+  longitude: number | null;
+  city: string | null;
+  error?: Error | IGeolocationPositionError;
+}
+
+interface IGeolocationCoordinates {
+  readonly accuracy: number;
+  readonly altitude: number | null;
+  readonly altitudeAccuracy: number | null;
+  readonly heading: number | null;
+  readonly latitude: number;
+  readonly longitude: number;
+  readonly speed: number | null;
+}
+
+interface IGeolocationPosition {
+  readonly coords: IGeolocationCoordinates;
+  readonly timestamp: number;
+}
+
+interface IGeocodeLatLng {
+  (lat: number, lon: number): Promise<string | null>;
+}
+
+interface IDadataGeolocateSuggestionDTO {
+  value: string;
+  unrestricted_value: string;
+  data: {
+    city: string;
+  };
+}
+
+interface IDadataGeolocateDTO {
+  suggestions: IDadataGeolocateSuggestionDTO[];
+}
+
+const useGeolocation = (): IGeolocationState => {
+  const [state, setState] = useState<IGeolocationState>({
+    latitude: null,
+    longitude: null,
+    city: null,
+  });
+
+  const geocodeLatLng: IGeocodeLatLng = async (lat, lon) => {
+    const token = '47946fcc58019ff6bc2ed32ca8008dd7e707ab55';
+    const postReverseGeocoding = createApiDef<IDadataGeolocateDTO>({
+      url: 'https://suggestions.dadata.ru/suggestions/api/4_1/rs/geolocate/address',
+      type: 'post',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `Token ${token}`,
+      },
+      withCredentials: false,
+    });
+
+    const res = await postReverseGeocoding({
+      data: { lat, lon, count: 1 },
+    });
+
+    return res ? res.suggestions[0].data.city : null;
+  };
+
+  const onEvent = async (event: IGeolocationPosition) => {
+    let city: string | null = null;
+    try {
+      city = await geocodeLatLng(event.coords.latitude, event.coords.longitude);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error('Reverse geocoding failed');
+    } finally {
+      setState({
+        latitude: event.coords.latitude,
+        longitude: event.coords.longitude,
+        city,
+      });
+    }
+  };
+  const onEventError = (error: IGeolocationPositionError) => {
+    setState((oldState) => ({ ...oldState, error }));
+  };
+
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(onEvent, onEventError);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return state;
+};
+
+export default useGeolocation;

--- a/packages/client/src/pages/gamePage/hooks/useWindowSize.ts
+++ b/packages/client/src/pages/gamePage/hooks/useWindowSize.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 export function useWindowSize() {
   const [windowSize, setWindowSize] = useState({
@@ -6,14 +6,14 @@ export function useWindowSize() {
     height: 0,
   });
 
-  useEffect(() => {
-    const handleResize = () => {
-      setWindowSize({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
-    };
+  const handleResize = () => {
+    setWindowSize({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  };
 
+  useLayoutEffect(() => {
     window.addEventListener('resize', handleResize);
 
     handleResize();

--- a/packages/client/src/pages/gamePage/utils/Scenario.ts
+++ b/packages/client/src/pages/gamePage/utils/Scenario.ts
@@ -1,5 +1,5 @@
 import roadImg from '../assets/scenario/road.png';
-import { Tree } from './roadside/Tree';
+import { Tree, CityLimitSign } from './roadside';
 import { GameConfig } from './game.config';
 import { Obstacle } from './Obstacle';
 
@@ -29,6 +29,8 @@ export class Scenario {
 
   oil!: Obstacle;
 
+  cityLimitSign?: CityLimitSign;
+
   /**
    * Конструктор класса сценария.
    * @param {HTMLCanvasElement} canvas - Элемент Canvas.
@@ -49,6 +51,7 @@ export class Scenario {
     this.roadImage.src = roadImg;
 
     this.createTrees();
+    this.createCityLimitSign();
   }
 
   /**
@@ -69,6 +72,10 @@ export class Scenario {
     this.trees.forEach((tree) => {
       tree.draw(this.context);
     });
+
+    if (this.isThereCityLimitSign()) {
+      this.cityLimitSign?.draw(this.context);
+    }
   }
 
   /**
@@ -89,6 +96,10 @@ export class Scenario {
     }
 
     this.updateTrees(speed);
+
+    if (this.isThereCityLimitSign()) {
+      this.cityLimitSign?.update(this.canvas.height, speed);
+    }
   }
 
   /**
@@ -133,7 +144,6 @@ export class Scenario {
    * Обновление препятствий
    * @param {number} speed - Скорость смещения.
    */
-
   updateObstacles(speed: number) {
     if (this.isThereOil()) {
       this.oil.update(this.canvas.height, speed);
@@ -143,11 +153,11 @@ export class Scenario {
       this.puddle.update(this.canvas.height, speed);
     }
   }
+
   /**
    * Пытается установить препятствие в свободную полосу
    * @param {number} emptyLane - свободная полоса.
    */
-
   tryPutAnObstacleOnRoad(emptyLane: number) {
     const newObstacleProbability = Math.random();
 
@@ -160,7 +170,6 @@ export class Scenario {
    *  Устанавливает препятствие в свободную полосу
    * @param {number} emptyLane - свободная полоса.
    */
-
   putAnObstacleOnRoad(emptyLane: number) {
     const typeObstacleProbability = Math.random();
 
@@ -174,7 +183,6 @@ export class Scenario {
   /**
    * Создание лужи
    */
-
   createPuddle(emptyLane: number) {
     if (!this.puddle || !this.puddle.isOnRoad) {
       this.puddle = new Obstacle(emptyLane, 'puddle');
@@ -184,7 +192,6 @@ export class Scenario {
   /**
    * Создание масляной лужи
    */
-
   createOil(emptyLane: number) {
     if (!this.oil || !this.oil.isOnRoad) {
       this.oil = new Obstacle(emptyLane, 'oil');
@@ -195,7 +202,6 @@ export class Scenario {
    * Проверка, что препятстиве есть на дороге
    * @return {boolean} .
    */
-
   hasObstaclesOnRoad(): boolean {
     return this.isThereOil() || this.isTherePuddle();
   }
@@ -206,5 +212,21 @@ export class Scenario {
 
   isTherePuddle() {
     return this.puddle && this.puddle.isOnRoad;
+  }
+
+  /**
+   * Создание дорожного знака с наименованием города игрока
+   */
+  createCityLimitSign() {
+    if (!GameConfig.player.city) return;
+    this.cityLimitSign = new CityLimitSign(100);
+  }
+
+  /**
+   * Проверка, что дорожный знаа с наименованием города есть на дороге
+   * @return {boolean} .
+   */
+  isThereCityLimitSign() {
+    return this.cityLimitSign && this.cityLimitSign.isOnScreen;
   }
 }

--- a/packages/client/src/pages/gamePage/utils/game.config.ts
+++ b/packages/client/src/pages/gamePage/utils/game.config.ts
@@ -30,6 +30,7 @@ export const GameConfig = {
   },
   player: {
     carType: 0,
+    city: '',
   },
   obstacle: {
     pointsLossOnPuddle: 100,

--- a/packages/client/src/pages/gamePage/utils/roadside/CityLimitSign.ts
+++ b/packages/client/src/pages/gamePage/utils/roadside/CityLimitSign.ts
@@ -1,0 +1,78 @@
+import { GameConfig } from '@/pages/gamePage/utils/game.config';
+
+/**
+ * Дорожный знак, обозначающий окончание города
+ */
+export class CityLimitSign {
+  width = 80;
+
+  height = 20;
+
+  x: number;
+
+  y: number;
+
+  padding = 5;
+
+  isOnScreen: boolean;
+
+  /**
+   * Конструктор класса.
+   * @param {number} initialPosition - Начальная позиция.
+   */
+  constructor(initialPosition: number) {
+    this.x = 660;
+    this.y = initialPosition;
+    this.isOnScreen = true;
+  }
+
+  /**
+   * Отрисовка знака
+   * @param {CanvasRenderingContext2D} context - Контекст Canvas.
+   */
+  draw(context: CanvasRenderingContext2D) {
+    const { city } = GameConfig.player;
+
+    context.save();
+    context.font = '16px Arial';
+    context.textBaseline = 'top';
+    this.width = Math.floor(context.measureText(city).width);
+
+    context.fillStyle = 'white';
+    context.strokeStyle = 'black';
+    context.beginPath();
+    context.roundRect(
+      this.x - this.padding,
+      this.y - this.padding,
+      this.width + this.padding * 2,
+      this.height + this.padding * 2,
+      5
+    );
+    context.stroke();
+    context.fill();
+    context.closePath();
+
+    context.fillStyle = 'black';
+    context.fillText(city, this.x, this.y);
+
+    context.strokeStyle = 'rgba(255, 0, 0, 0.7)';
+    context.lineWidth = 4;
+    context.beginPath();
+    context.moveTo(this.x + this.width / 4, this.y + this.height + this.padding);
+    context.lineTo(this.x + this.width - this.width / 4, this.y - this.padding);
+    context.stroke();
+    context.closePath();
+
+    context.restore();
+  }
+
+  /**
+   * Обновление дорожного знака
+   * @param {number} maxY - Максимально допустимое значение Y (высота Canvas)
+   * @param {number} speed - Скорость смещения.
+   */
+  update(maxY: number, speed: number) {
+    this.y += speed;
+    this.isOnScreen = this.y < maxY;
+  }
+}

--- a/packages/client/src/pages/gamePage/utils/roadside/index.ts
+++ b/packages/client/src/pages/gamePage/utils/roadside/index.ts
@@ -1,1 +1,2 @@
 export { Tree } from './Tree';
+export { CityLimitSign } from './CityLimitSign';

--- a/packages/client/src/utils/api/makeRequest.ts
+++ b/packages/client/src/utils/api/makeRequest.ts
@@ -9,6 +9,7 @@ export const makeRequest = async <T>({
   data,
   baseURL,
   headers,
+  withCredentials,
   onSuccess,
   onError,
 }: IMakeRequestParams<T>) => {
@@ -17,7 +18,7 @@ export const makeRequest = async <T>({
     method: type,
     baseURL: baseURL || `${API_HOST}${API_PATH}`,
     timeout: 2000,
-    withCredentials: true,
+    withCredentials: typeof withCredentials === 'undefined' ? true : withCredentials,
     headers: { ...headers },
     data: data || null,
     params: urlParams || null,

--- a/packages/client/src/utils/api/typings.ts
+++ b/packages/client/src/utils/api/typings.ts
@@ -5,6 +5,7 @@ export interface IDefParams {
   url: typeof apiPaths[keyof typeof apiPaths];
   baseURL?: string;
   headers?: Record<string, string>;
+  withCredentials?: boolean;
 }
 
 export interface IErrorRes {

--- a/packages/client/src/utils/router/router.test.tsx
+++ b/packages/client/src/utils/router/router.test.tsx
@@ -10,6 +10,13 @@ describe('Router', () => {
         removeListener: jest.fn(),
       })),
     });
+
+    Object.defineProperty(global.navigator, 'geolocation', {
+      writable: true,
+      value: {
+        getCurrentPosition: jest.fn(),
+      },
+    });
   });
 
   test('should correct render home page', () => {


### PR DESCRIPTION
### Какую задачу решаем

Данный PR:
- добавляет хук, который получает геолокацию игрока (Geolocation API), после чего делает запрос к [API обратного геокодирования](https://dadata.ru/api/geolocate/) сервиса **DaData** и получает название ближайшего города
- если город определён - рисует на обочине дорожный знак с названием города
- добавляет опцию `withCredentials` в метод `makeRequest` (нужно для запроса к DaData)
- в хуке `useWindowSize` заменяет `useEffect` на `useLayoutEffect`, для синхронной отработки хука и возвращения им ненулевых значений высоты и ширины

### Скриншоты/видяшка (если есть)
<img width="782" alt="Screenshot 2023-01-09 at 22 36 26" src="https://user-images.githubusercontent.com/15361093/211393163-d4ac3007-9f24-4b8f-9459-d898ad1019e0.png">
